### PR TITLE
go.mod: declare we're github.com/Psiphon-Labs/net

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module golang.org/x/net
+module github.com/Psiphon-Labs/net
 
 go 1.11
 


### PR DESCRIPTION
Otherwise, using this software from a tool that uses go modules, such
as github.com/ooni/probe-engine, leads to this error:

```
go: github.com/Psiphon-Labs/net@v0.0.0-20191009144256-e0f44e7d5292: parsing go.mod:
	module declares its path as: golang.org/x/net
	        but was required as: github.com/Psiphon-Labs/net
```